### PR TITLE
Add Bicho::Client#version to retrieve Bugzilla API version

### DIFF
--- a/lib/bicho/client.rb
+++ b/lib/bicho/client.rb
@@ -172,6 +172,12 @@ module Bicho
       end
     end
 
+    # Return Bugzilla API version
+    def version
+      ret = @client.call('Bugzilla.version')
+      handle_faults(ret)
+      ret["version"]
+    end
     # Search for a bug
     #
     # +query+ has to be either a +Query+ object or

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -1,0 +1,21 @@
+require File.join(File.dirname(__FILE__), 'helper')
+
+#
+# Test getting the version of the Bugzilla API
+#
+class Version_test < Test::Unit::TestCase
+  def test_version_gnome
+    Bicho.client = Bicho::Client.new('https://bugzilla.gnome.org')
+
+    ret  = Bicho::client.version
+    assert ret =~ /3.4/ # https://bugzilla.gnome.org/ is at 3.4.13 as of Jan/2015
+  end
+
+  def test_version_suse
+    Bicho.client = Bicho::Client.new('https://bugzilla.suse.com')
+
+    ret  = Bicho::client.version
+    assert ret =~ /4.4/ #https://bugzilla.suse.com is at 4.4.6 as of Jan/2015
+  end
+
+end


### PR DESCRIPTION
The API changed between 3.x and 4.x, esp. the structure of the bug
data returned. This helps bicho clients to adapt accordingly.