### PR TITLE
Detect and download supportconfig attachments

### DIFF
--- a/lib/bicho/cli/commands/show.rb
+++ b/lib/bicho/cli/commands/show.rb
@@ -29,10 +29,46 @@ require 'bicho/client'
 module Bicho::CLI::Commands
   # Command to display bug information.
   class Show < ::Bicho::CLI::Command
+    private
+
+    # check for supportconfigs and download
+    def download_if_supportconfig(bug, attachment)
+      if (attachment.content_type == 'application/x-gzip' || attachment.content_type == 'application/x-bzip-compressed-tar') &&
+         attachment.summary =~ /supportconfig/i
+        filename = "bsc#{bug.id}-#{attachment.id}-#{attachment.props['file_name']}"
+        t.say("Downloading to #{t.color(filename, :even_row)}")
+        begin
+          data = attachment.data
+          File.open(filename, 'w') do |f|
+            f.write data.read
+          end
+        rescue StandardError => e
+          t.say("#{t.color('Error:', :error)} Download of #{filename} failed: #{e}")
+          raise
+        end
+      end
+    end
+
+    # handle bug attachments
+    # (show or download supportconfig)
+    def handle_attachments(bug, download_supportconfigs)
+      t.say("Bug #{t.color(bug.id.to_s, :headline)} has #{bug.attachments.size} attachments")
+      bug.attachments.each do |attachment|
+        if download_supportconfigs
+          download_if_supportconfig(bug, attachment)
+        else
+          # no download, just show
+          t.say(" #{attachment.id} (#{attachment.props['file_name']}:#{attachment.content_type}) #{attachment.summary}")
+        end
+      end
+    end
+
+    public
+
     options do
       opt :format, "Format string, eg. '%{id}:%{priority}:%{summary}'", type: :string
-      opt :attachments, "Show attachments"
-      opt :supportconfig, "Download supportconfig attachments (only if --attachments is given)"
+      opt :attachments, 'Show attachments'
+      opt :supportconfig, 'Download supportconfig attachments (only if --attachments is given)'
     end
 
     def do(global_opts, opts, args)
@@ -41,29 +77,7 @@ module Bicho::CLI::Commands
         if opts[:format]
           t.say(bug.format(opts[:format]))
         elsif opts[:attachments]
-          t.say("Bug #{t.color(bug.id.to_s, :headline)} has #{bug.attachments.size} attachments")
-          bug.attachments.each do |attachment|
-            if opts[:supportconfig]
-              # check for supportconfigs
-              if (attachment.content_type == "application/x-gzip" || attachment.content_type == "application/x-bzip-compressed-tar") &&
-                attachment.summary =~ /supportconfig/i
-                filename = "bsc#{bug.id}-#{attachment.id}-#{attachment.props['file_name']}"
-                t.say("Downloading to #{t.color(filename, :even_row)}")
-                begin
-                  data = attachment.data
-                  File.open(filename, 'w') do |f|
-                    f.write data.read
-                  end
-                rescue Exception => e
-                  t.say("#{t.color("Error:", :error)} Download of #{filename} failed: #{e}")
-                  raise
-                end
-              end
-            else
-              # no download, just show
-              t.say(" #{attachment.id} (#{attachment.props['file_name']}:#{attachment.content_type}) #{attachment.summary}")
-            end
-          end
+          handle_attachments(bug, opts[:supportconfig])
         else
           t.say("#{t.color(bug.id.to_s, :headline)} #{bug.summary}")
         end

--- a/lib/bicho/cli/commands/show.rb
+++ b/lib/bicho/cli/commands/show.rb
@@ -31,6 +31,7 @@ module Bicho::CLI::Commands
   class Show < ::Bicho::CLI::Command
     options do
       opt :format, "Format string, eg. '%{id}:%{priority}:%{summary}'", type: :string
+      opt :attachments, "Show attachments"
     end
 
     def do(global_opts, opts, args)
@@ -38,6 +39,11 @@ module Bicho::CLI::Commands
       client.get_bugs(*args).each do |bug|
         if opts[:format]
           t.say(bug.format(opts[:format]))
+        elsif opts[:attachments]
+          t.say("Bug #{t.color(bug.id.to_s, :headline)} has #{bug.attachments.size} attachments")
+          bug.attachments.each do |attachment|
+            t.say(" #{attachment.id} (#{attachment.content_type}) #{attachment.summary}")
+          end
         else
           t.say("#{t.color(bug.id.to_s, :headline)} #{bug.summary}")
         end


### PR DESCRIPTION
This PR adds the following options to `show`

- `--attachments` list attachments (id, content_type, summary) of matching bugs
- `--supportconfig` downloads supportconfig attachments