### PR TITLE
Check host component of site_url

### DIFF
--- a/lib/bicho/client.rb
+++ b/lib/bicho/client.rb
@@ -116,6 +116,9 @@ module Bicho
 
       # Don't modify the original url
       @site_url = site_url.is_a?(URI) ? site_url.clone : URI.parse(site_url)
+      unless @site_url.host
+        raise "Malformed site url, can't detect host component"
+      end
 
       api_url = @site_url.clone
       api_url.path = '/xmlrpc.cgi'


### PR DESCRIPTION
Otherwise plugins/novell.rb will fail in transform_api_url_hook() calling `url.host.include?`